### PR TITLE
Fixed issue #31 that progress dialog ("processing") never got dismissed

### DIFF
--- a/tedpicker/src/main/java/com/gun0912/tedpicker/CwacCameraFragment.java
+++ b/tedpicker/src/main/java/com/gun0912/tedpicker/CwacCameraFragment.java
@@ -328,8 +328,6 @@ public class CwacCameraFragment extends Fragment implements View.OnClickListener
         Log.d("gun0912","takePicture()");
 
         try {
-            cameraView.takePicture(false, true);
-            btn_take_picture.setEnabled(false);
             animateShutter();
         } catch (IllegalStateException ex) {
 
@@ -374,6 +372,9 @@ public class CwacCameraFragment extends Fragment implements View.OnClickListener
             public void onAnimationEnd(Animator animation) {
                 vShutter.setVisibility(View.GONE);
                 mProgressDialog.show();
+
+                cameraView.takePicture(false, true);
+                btn_take_picture.setEnabled(false);
 
             }
         });


### PR DESCRIPTION
Fixed issue #31 that progress dialog ("processing") never got dismissed. This occurred in cases where taking the photo occurred so fast that it was completed before the shutter animation. Since the progress dialog gets shown at the end of the shutter animation and is dismissed after the photo is taken, the dialog never got dismissed.

In the new implementation, the shutter animation is always triggered first and taking the photo happens only after the animation is completed. In principle, this could mean slightly more latency from clicking the shutter to completion but this difference is insignificant.

refs #31